### PR TITLE
Feat/add ansible labels

### DIFF
--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -96,5 +96,5 @@ resource "google_compute_instance" "workers" {
   labels = {
     role = "worker"
     subnet_type = "private"
-  } }
+  }
 }


### PR DESCRIPTION
This pull request adds descriptive labels to all Google Compute Engine instances defined in the Terraform configuration. The new labels help identify the role and subnet type of each instance, which will be used later to query the IP addresses of the virtual machines.

Labeling improvements for compute instances:

* Added `labels` blocks to the `edge`, `master`, and `workers` compute instances in `terraform/compute.tf`, specifying each instance's `role` (edge, master, worker) and `subnet_type` (public or private). [[1]](diffhunk://#diff-5f20fb26fd08d594341187a22faed386fc3405399736046be8eea7e2047a7408R24-R28) [[2]](diffhunk://#diff-5f20fb26fd08d594341187a22faed386fc3405399736046be8eea7e2047a7408R52-R56) [[3]](diffhunk://#diff-5f20fb26fd08d594341187a22faed386fc3405399736046be8eea7e2047a7408R95-R99)