### PR TITLE
Add the SSH key pair of the Ansible runner into the `authorized_keys`…

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -57,6 +57,8 @@ jobs:
           TF_VAR_project_number: ${{ env.PROJECT_NUMBER }}
           TF_VAR_ssh_public_key_ruddy: ${{ secrets.SSH_PUBLIC_KEY_RUDDY }}
           TF_VAR_ssh_public_key_landry: ${{ secrets.SSH_PUBLIC_KEY_LANDRY }}
+          TF_VAR_ssh_public_key_ansible_runner: ${{ secrets.SSH_PUBLIC_KEY_ANSIBLE_RUNNER }}
+
         run: |
           terraform -chdir=./terraform plan -no-color -input=false -out=tfplan
 
@@ -69,5 +71,6 @@ jobs:
           TF_VAR_project_number: ${{ env.PROJECT_NUMBER }}
           TF_VAR_ssh_public_key_ruddy: ${{ secrets.SSH_PUBLIC_KEY_RUDDY }}
           TF_VAR_ssh_public_key_landry: ${{ secrets.SSH_PUBLIC_KEY_LANDRY }}
+          TF_VAR_ssh_public_key_ansible_runner: ${{ secrets.SSH_PUBLIC_KEY_ANSIBLE_RUNNER }}
         run: |
           terraform -chdir=./terraform apply -auto-approve -input=false tfplan

--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -19,7 +19,7 @@ resource "google_compute_instance" "edge" {
   }
 
   metadata = {
-    ssh-keys = "${var.ssh_user}:${var.ssh_public_key_ruddy}\n${var.ssh_user}:${var.ssh_public_key_landry}"
+    ssh-keys = "${var.ssh_user}:${var.ssh_public_key_ruddy}\n${var.ssh_user}:${var.ssh_public_key_landry}\n${var.ssh_user}:${var.ssh_public_key_ansible_runner}"
   }
 
   labels = {
@@ -47,7 +47,7 @@ resource "google_compute_instance" "master" {
   }
 
   metadata = {
-    ssh-keys = "${var.ssh_user}:${var.ssh_public_key_ruddy}\n${var.ssh_user}:${var.ssh_public_key_landry}"
+    ssh-keys = "${var.ssh_user}:${var.ssh_public_key_ruddy}\n${var.ssh_user}:${var.ssh_public_key_landry}\n${var.ssh_user}:${var.ssh_public_key_ansible_runner}"
   }
 
   labels = {
@@ -90,7 +90,7 @@ resource "google_compute_instance" "workers" {
   }
 
   metadata = {
-    ssh-keys = "${var.ssh_user}:${var.ssh_public_key_ruddy}\n${var.ssh_user}:${var.ssh_public_key_landry}"
+    ssh-keys = "${var.ssh_user}:${var.ssh_public_key_ruddy}\n${var.ssh_user}:${var.ssh_public_key_landry}\n${var.ssh_user}:${var.ssh_public_key_ansible_runner}"
   }
 
   labels = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,6 +47,12 @@ variable "ssh_public_key_landry" {
   sensitive   = true # Prevents Terraform from showing the key in plan outputs
 }
 
+variable "ssh_public_key_ansible_runner" {
+  description = "Ansible runner's Public SSH key to be added to the VMs."
+  type        = string
+  sensitive   = true # Prevents Terraform from showing the key in plan outputs
+}
+
 variable "infrastructure_tier" {
   description = "Tier of infrastructure: minimal, standard, or high-performance"
   type        = string


### PR DESCRIPTION
This pull request adds support for provisioning an additional SSH public key (for the Ansible runner) to all compute instances managed by Terraform, and updates the GitHub Actions workflow to supply this new key as a secret. This change ensures that the Ansible runner can securely access all relevant VMs for configuration management.

**Infrastructure provisioning updates:**

* Added a new Terraform variable `ssh_public_key_ansible_runner` to accept the Ansible runner's SSH key, marked as sensitive to avoid leaking secrets in plan outputs.
* Updated the `metadata` block for all compute instance resources (`edge`, `master`, `workers`) in `terraform/compute.tf` to include the Ansible runner's SSH key in the `ssh-keys` field, ensuring access for the Ansible runner alongside existing users. [[1]](diffhunk://#diff-5f20fb26fd08d594341187a22faed386fc3405399736046be8eea7e2047a7408L22-R22) [[2]](diffhunk://#diff-5f20fb26fd08d594341187a22faed386fc3405399736046be8eea7e2047a7408L50-R50) [[3]](diffhunk://#diff-5f20fb26fd08d594341187a22faed386fc3405399736046be8eea7e2047a7408L93-R93)

**CI/CD workflow changes:**

* Modified the GitHub Actions workflow (`.github/workflows/infrastructure.yml`) to pass the new `TF_VAR_ssh_public_key_ansible_runner` secret to both the Terraform plan and apply steps, so that the key is available during infrastructure provisioning. [[1]](diffhunk://#diff-87064d625758a43d5c34f6188c42c132d0df6dd171c0f93185cef24ba9c21f40R60-R61) [[2]](diffhunk://#diff-87064d625758a43d5c34f6188c42c132d0df6dd171c0f93185cef24ba9c21f40R74)…