### PR TITLE
Add the SSH public key in the destroy workflow.

### DIFF
--- a/.github/workflows/destroy-infrastructure.yml
+++ b/.github/workflows/destroy-infrastructure.yml
@@ -49,5 +49,6 @@ jobs:
           TF_VAR_project_number: ${{ env.PROJECT_NUMBER }}
           TF_VAR_ssh_public_key_ruddy: ${{ secrets.SSH_PUBLIC_KEY_RUDDY }}
           TF_VAR_ssh_public_key_landry: ${{ secrets.SSH_PUBLIC_KEY_LANDRY }}
+          TF_VAR_ssh_public_key_ansible_runner: ${{ secrets.SSH_PUBLIC_KEY_ANSIBLE_RUNNER }}
         run: |
           terraform -chdir=./terraform destroy -auto-approve -input=false


### PR DESCRIPTION
This pull request introduces a small update to the Terraform destroy workflow by adding a new environment variable for the Ansible runner's SSH public key.

* Infrastructure workflow update:
  * [`.github/workflows/destroy-infrastructure.yml`](diffhunk://#diff-fe07d3a28a07bb2b6c8064d95cb4b53452c4f68bdca753937f5a5a05283fa16eR52): Added the `TF_VAR_ssh_public_key_ansible_runner` environment variable to pass the Ansible runner's SSH public key to Terraform.