### PR TITLE
Add Ansible role to install essential system packages

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Update apt cache
+  apt:
+    update_cache: yes
+
+- name: Install essential system packages
+  apt:
+    name:
+      - vim
+      - curl
+      - wget
+      - unzip
+      - net-tools
+      - htop
+      - git
+      - python3-pip
+      - software-properties-common
+    state: present


### PR DESCRIPTION
- Create the missing `common` role and add tasks to update apt cache and install utilities like `vim`, `curl`, `git`, and others.