### PR TITLE
Configure SSH tunneling for private subnet access in GCP Ansible grou…

### DIFF
--- a/ansible/group_vars/gcp_subnet_type_private.yml
+++ b/ansible/group_vars/gcp_subnet_type_private.yml
@@ -1,0 +1,5 @@
+---
+# 1. We access the 'ansible_host' (Public IP) of the edge node dynamically.
+# 2. We use 'ssh -W' to tunnel the connection.
+ansible_ssh_common_args: >-
+  -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p -q user@{{ hostvars['edge-01']['ansible_host'] }}"


### PR DESCRIPTION
This pull request introduces a configuration change to how Ansible connects to private subnet nodes in GCP. The update sets up SSH tunneling through an edge node.

Connection configuration enhancement:

* Added the `ansible_ssh_common_args` setting in `group_vars/gcp_subnet_type_private.yml` to use SSH's `ProxyCommand` for tunneling connections through the edge node's public IP.