### PR TITLE
Change SSH key type in the workflow and the ansible config

### DIFF
--- a/.github/workflows/configuration.yml
+++ b/.github/workflows/configuration.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Set SSH Key
         run: |
           mkdir -p ~/.ssh/
-          echo "${{ secrets.SSH_PRIVATE_KEY_ANSIBLE_RUNNER }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
+          echo "${{ secrets.SSH_PRIVATE_KEY_ANSIBLE_RUNNER }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
 
       - name: Run Ansible Playbook
         working-directory: ./ansible

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -9,7 +9,7 @@ host_key_checking = False
 remote_user = user
 
 # Set location of the private key
-private_key_file = ~/.ssh/id_rsa
+private_key_file = ~/.ssh/id_ed25519
 
 [ssh_connection]
 # Pipes module code over the SSH session instead of copying it into `/tmp` and then executing it


### PR DESCRIPTION
This pull request updates the SSH key type used for Ansible operations from RSA to ED25519. The changes ensure that both the GitHub Actions workflow and Ansible configuration are aligned to use the new key type.

**SSH Key Type Migration:**

* Updated the GitHub Actions workflow (`.github/workflows/configuration.yml`) to use the `id_ed25519` SSH private key instead of `id_rsa` for Ansible runner authentication.
* Changed the Ansible configuration (`ansible/ansible.cfg`) to reference the `id_ed25519` private key file instead of `id_rsa`.