### PR TITLE
Separate Download and decompress

### DIFF
--- a/ansible/roles/spark_base/tasks/main.yml
+++ b/ansible/roles/spark_base/tasks/main.yml
@@ -21,13 +21,20 @@
     state: directory
     mode: '0755'
 
-- name: Download and Unarchive Spark
+- name: Download Spark
   get_url:
     url: "{{ spark_download_url }}"
-    dest: "{{ spark_destination_dir }}"
+    dest: "{{ spark_destination_dir }}.tgz"
+    checksum: "{{ spark_checksum }}"
+
+- name: Unarchive Spark
+  unarchive:
+    src: "{{ spark_destination_dir }}.tgz"
+    dest: "{{ spark_install_parent_dir }}"
     owner: "{{ spark_user }}"
     group: "{{ spark_group }}"
-    checksum: "{{ spark_checksum }}"
+    remote_src: yes
+    creates: "{{ spark_destination_dir }}"
 
 - name: Create /opt/spark symlink
   file:


### PR DESCRIPTION
This pull request updates the Spark installation process in the Ansible `spark_base` role to separate the download and extraction steps, and to improve idempotency and checksum verification.

Improvements to Spark installation process:

* Split the combined "Download and Unarchive Spark" task into two separate tasks: one for downloading the Spark tarball using `get_url`, and another for extracting it using `unarchive`.
* The `get_url` task now saves the downloaded file as a `.tgz` archive and verifies it using the provided checksum.
* The `unarchive` task extracts the downloaded archive to the installation directory, sets the correct ownership, uses the archive from the remote host, and only runs if the target directory does not already exist (using `creates`).