### PR TITLE
Add HDFS NameNode service setup in Hadoop Master role

### DIFF
--- a/ansible/roles/hadoop_master/tasks/main.yml
+++ b/ansible/roles/hadoop_master/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+- name: Install HDFS NameNode Service
+  template:
+    src: hdfs-namenode.service.j2
+    dest: /etc/systemd/system/hdfs-namenode.service
+
+# 2. Format the NameNode (if not already formatted)
+- name: Check if NameNode is formatted
+  stat:
+    path: "/var/lib/hadoop/dfs/name/current/VERSION"
+  register: namenode_marker
+
+- name: Ensure NameNode storage directory exists
+  file:
+    path: /var/lib/hadoop/dfs/name
+    state: directory
+    owner: "{{ hadoop_user }}"
+    group: "{{ hadoop_group }}"
+    mode: '0700' # Secure: Only the owner can read/write metadata
+    recurse: yes
+  when: not namenode_marker.stat.exists
+
+- name: Format NameNode
+  command: "{{ hadoop_link_dir }}/bin/hdfs namenode -format -force"
+  become_user: "{{ hadoop_user }}"
+  # ONLY run if the directory is empty/missing
+  when: not namenode_marker.stat.exists
+
+# 3. Start the Service
+- name: Start and Enable NameNode
+  ansible.builtin.systemd:
+    name: hdfs-namenode
+    state: started
+    enabled: yes
+    daemon_reload: true
+

--- a/ansible/roles/hadoop_master/templates/hdfs-namenode.service.j2
+++ b/ansible/roles/hadoop_master/templates/hdfs-namenode.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Hadoop NameNode
+After=network.target
+
+[Service]
+User={{ hadoop_user }}
+Group={{ hadoop_group }}
+Type=simple
+Environment="JAVA_HOME={{ java_home }}"
+# The 'hdfs' command handles the classpath and environment setup for us
+ExecStart={{ hadoop_link_dir }}/bin/hdfs namenode
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -10,3 +10,15 @@
     - java
     - spark_base # Spark
     - hadoop_base # HDFS
+
+# ==========================================
+# 2. Master Node Configuration
+# ==========================================
+
+- name: Apply Master Node Configuration
+  hosts: gcp_role_master
+  become: yes
+  remote_user: user
+  roles:
+    - hadoop_master # HDFS Master Node Configuration
+  tags: master


### PR DESCRIPTION
```
### Summary

This pull request adds configuration and setup for the HDFS NameNode service in the Hadoop Master role.

### Changes
- Added a systemd unit file template (`hdfs-namenode.service.j2`) for the NameNode service.
- Implemented tasks to provision and format the NameNode if not already formatted.
- Configured the system to start and enable the HDFS NameNode service.
- Updated `site.yml` to include the Hadoop Master role updates for NameNode setup.
```