### PR TITLE
Add Spark Master service setup in Ansible role

### DIFF
--- a/ansible/roles/spark_master/tasks/main.yml
+++ b/ansible/roles/spark_master/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Install Spark Master Service
+  template:
+    src: spark-master.service.j2
+    dest: /etc/systemd/system/spark-master.service
+
+- name: Start and Enable Spark Master
+  systemd:
+    name: spark-master
+    state: started
+    enabled: yes
+    daemon_reload: yes

--- a/ansible/roles/spark_master/templates/spark-master.service.j2
+++ b/ansible/roles/spark_master/templates/spark-master.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=Apache Spark Master
+After=network.target
+
+[Service]
+User={{ spark_user }}
+Group={{ spark_group }}
+Type=simple
+WorkingDirectory={{ spark_link_dir }}
+Environment="JAVA_HOME={{ java_home }}"
+Environment="SPARK_HOME={{ spark_link_dir }}"
+# We bind to port 7077 (RPC) and 8080 (Web UI)
+# We use the internal IP (ansible_host) so it is accessible from the VPC
+ExecStart={{ spark_link_dir }}/bin/spark-class org.apache.spark.deploy.master.Master --ip {{ ansible_host }} --port 7077 --webui-port 8080
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -10,6 +10,7 @@
     - java
     - spark_base # Spark
     - hadoop_base # HDFS
+  tags: common
 
 # ==========================================
 # 2. Master Node Configuration
@@ -20,6 +21,7 @@
   remote_user: user
   roles:
     - hadoop_master # HDFS Master Node Configuration
+    - spark_master # Spark Master Node Configuration
   tags: master
 
 # ==========================================


### PR DESCRIPTION
This pull request introduces automation for deploying and managing the Spark Master service using Ansible. The main improvements include adding a templated systemd service for Spark Master, updating the master node configuration to include this role, and ensuring the service is started and enabled automatically.

**Spark Master Service Automation:**

* Added a new Ansible task in `spark_master` to install a templated systemd service for Spark Master and ensure it is started and enabled on boot.
* Created a new `spark-master.service.j2` template that defines the systemd unit for Spark Master, including user, group, environment variables, working directory, and startup command.

**Configuration Updates:**

* Updated `site.yml` to include the `spark_master` role in the master node configuration, ensuring Spark Master is set up on the correct hosts.
* Added a `common` tag to the base roles in `site.yml` for improved playbook organization and targeting.