### PR TITLE
Add Spark Worker service setup in Ansible role

### DIFF
--- a/ansible/roles/spark_worker/tasks/main.yml
+++ b/ansible/roles/spark_worker/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Install Spark Worker Service
+  template:
+    src: spark-worker.service.j2
+    dest: /etc/systemd/system/spark-worker.service
+
+- name: Start and Enable Spark Worker
+  systemd:
+    name: spark-worker
+    state: started
+    enabled: yes
+    daemon_reload: true

--- a/ansible/roles/spark_worker/templates/spark-worker.service.j2
+++ b/ansible/roles/spark_worker/templates/spark-worker.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=Apache Spark Worker
+After=network.target
+
+[Service]
+User={{ spark_user }}
+Group={{ spark_group }}
+Type=simple
+WorkingDirectory={{ spark_link_dir }}
+Environment="JAVA_HOME={{ java_home }}"
+Environment="SPARK_HOME={{ spark_link_dir }}"
+ExecStart={{ spark_link_dir }}/bin/spark-class org.apache.spark.deploy.worker.Worker spark://{{ hostvars['spk-mst-01']['ansible_host'] }}:7077
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -33,4 +33,5 @@
   remote_user: user
   roles:
     - hadoop_worker # HDFS Worker Node Configuration
+    - spark_worker # Spark Worker Node Configuration
   tags: worker


### PR DESCRIPTION
This pull request adds configuration management for Spark Worker nodes to the Ansible deployment. The main changes include introducing a new Ansible role for Spark Worker, creating a systemd service template for managing the Spark Worker process, and ensuring the service is started and enabled on worker nodes.

**Spark Worker Role Addition:**

* Added the `spark_worker` role to the worker node playbook in `ansible/site.yml` to automate Spark Worker setup.

**Service Management:**

* Created a systemd service template (`spark-worker.service.j2`) for the Spark Worker, specifying user, group, environment variables, and startup command.
* Added tasks in `ansible/roles/spark_worker/tasks/main.yml` to install the service file and ensure the Spark Worker service is started and enabled on boot.