### PR TITLE
Add Python role to Ansible setup and refine package installation in C…

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Update apt cache
-  apt:
-    update_cache: yes
-
 - name: Install essential system packages
   apt:
     name:
@@ -13,6 +9,6 @@
       - net-tools
       - htop
       - git
-      - python3-pip
       - software-properties-common
     state: present
+    update_cache: yes

--- a/ansible/roles/python/tasks/main.yml
+++ b/ansible/roles/python/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Install essential system packages
+  apt:
+    name:
+      - python3-pip
+      - python3-numpy
+      - python3-pandas
+    state: present
+    update_cache: yes
+
+- name: Set PYSPARK_PYTHON environment variable
+  lineinfile:
+    path: /etc/environment
+    state: present
+    regexp: '^PYSPARK_PYTHON='
+    line: "PYSPARK_PYTHON=/usr/bin/python3"

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -8,6 +8,7 @@
   roles:
     - common # Installs vim, curl, htop, net-tools
     - java
+    - python
     - spark_base # Spark
     - hadoop_base # HDFS
   tags: common


### PR DESCRIPTION
This pull request reorganizes how Python-related system packages are installed and configures the environment for PySpark. The installation of Python packages has been moved from the `common` role to a new dedicated `python` role, which also sets the `PYSPARK_PYTHON` environment variable. The playbook is updated to include this new role.

**Python package management and environment configuration:**

* Added a new `python` role that installs `python3-pip`, `python3-numpy`, and `python3-pandas`, and sets the `PYSPARK_PYTHON` environment variable in `/etc/environment` (`ansible/roles/python/tasks/main.yml`).
* Updated the main playbook to include the new `python` role in the list of roles (`ansible/site.yml`).

**Refactoring of common role:**

* Removed the installation of `python3-pip` from the `common` role and consolidated `apt` tasks, moving `update_cache: yes` to the main install task (`ansible/roles/common/tasks/main.yml`). [[1]](diffhunk://#diff-f71972f4f701d5d39ae05911f6ee5fa33bd536f81046eac5c4f93054639a76d6L2-L5) [[2]](diffhunk://#diff-f71972f4f701d5d39ae05911f6ee5fa33bd536f81046eac5c4f93054639a76d6L16-R14)