### PR TITLE
Adding a missing forward slash.

### DIFF
--- a/spark/scripts/test.py
+++ b/spark/scripts/test.py
@@ -18,7 +18,7 @@ data_path = sys.argv[2].lstrip('/')
 try:
     df = spark.read.text(f"hdfs:///{data_path}")
     print(f"Read {df.count()} lines from HDFS.")
-    df.write.mode("overwrite").text(f"hdfs://{output_path}")
+    df.write.mode("overwrite").text(f"hdfs:///{output_path}")
 
 except Exception as e:
     print(f"HDFS Operation Failed: {e}")


### PR DESCRIPTION
This pull request makes a minor correction to the HDFS output path in the `spark/scripts/test.py` script to ensure the correct URI format is used. This change helps prevent potential path resolution errors when writing data back to HDFS.