### PR TITLE
Better specs for the virtual machines.

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -86,7 +86,7 @@ locals {
       master_boot_disk = 30       
       worker_boot_disk = 30
       
-      hdfs_disk_type  = "pd-balanced"   # SSD 
+      hdfs_disk_type  = "pd-balanced"   # Balanced persistent disk
       hdfs_disk = 50
     }
   }


### PR DESCRIPTION
This pull request updates the default infrastructure tier and adds a new configuration for the "standard" tier in the Terraform variables. The most important changes are:

Infrastructure tier defaults and configuration:

* Changed the default value of the `infrastructure_tier` variable from `"minimal"` to `"standard"` in `terraform/variables.tf`.
* Added a new `standard` configuration to the `locals` block, specifying machine types, boot disk sizes, and HDFS disk settings for the edge, master, and worker nodes in `terraform/variables.tf`.