### PR TITLE
Update Spark version and checksum in configuration

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -8,13 +8,13 @@ java_home: "/usr/lib/jvm/java-17-openjdk-amd64"
 # ==========================================
 # Spark Configuration
 # ==========================================
-spark_version: "3.5.7"
+spark_version: "3.5.8"
 spark_hadoop_version: "3"
-spark_checksum: "sha512:f3b7d5974d746b9aaecb19104473da91068b698a4d292177deb75deb83ef9dc7eb77062446940561ac9ab7ee3336fb421332b1c877292dab4ac1b6ca30f4f2e0"
+spark_checksum: "sha512:5d5d2e6e111182ee1210d4a46a17ae27107c7ccc70433da0ded3d8197e027f949b00445bb5678ed0c1d5c59f12993d9b9ed12e43686d5aad89a9ec570e93a083"
 
 # Parent installation directory (in case you want to change it)
 spark_install_parent_dir: "/opt"
-# Actual installation directory (/opt/spark-3.5.7-bin-hadoop3)
+# Actual installation directory (/opt/spark-3.5.8-bin-hadoop3)
 spark_destination_dir: "{{ spark_install_parent_dir }}/spark-{{ spark_version }}-bin-hadoop{{ spark_hadoop_version }}"
 # Where the symlink points to, which is independent of the version as it will always be /opt/spark
 spark_link_dir: "/opt/spark"


### PR DESCRIPTION
This pull request updates the Apache Spark version used in the configuration because the old one is not available anymore. The checksum and installation directory have also been updated accordingly.

Dependency update:

* Updated `spark_version` from `"3.5.7"` to `"3.5.8"`, changed the corresponding `spark_checksum`, and updated the documentation for the installation directory in `ansible/group_vars/all.yml`.