### PR TITLE
Add PySpark Word Count script with HDFS support and argument handling

### DIFF
--- a/spark/scripts/word_count.py
+++ b/spark/scripts/word_count.py
@@ -1,0 +1,60 @@
+import sys
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import explode, split, col
+
+def main():
+    """
+    Main function to execute the Word Count Spark job.
+    """
+    # Check for correct usage
+    if len(sys.argv) < 3:
+        print("Usage: spark-submit word_count.py <output_path> <data_path>", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse arguments
+    # Strip leading slash if present to avoid double slashes in HDFS paths
+    output_path = sys.argv[1].lstrip('/')
+    data_path = sys.argv[2].lstrip('/')
+
+    # Initialize Spark Session
+    spark = SparkSession.builder \
+        .appName("WordCount") \
+        .getOrCreate()
+
+    try:
+        # Read input data
+        # Assuming the input is a text file or directory of text files
+        input_uri = f"hdfs:///{data_path}"
+        lines = spark.read.text(input_uri)
+
+        # Perform Word Count
+        # 1. Split lines into words using whitespace as delimiter
+        # 2. Explode the array of words into separate rows
+        words = lines.select(
+            explode(
+                split(col("value"), "\\s+")
+            ).alias("word")
+        )
+
+        # 3. Filter out empty strings (result of multiple spaces)
+        words = words.filter(col("word") != "")
+
+        # 4. Group by word and count
+        word_counts = words.groupBy("word").count()
+
+        # Write output
+        output_uri = f"hdfs:///{output_path}"
+        
+        # Using CSV format to write (word, count) pairs
+        word_counts.write.mode("overwrite").csv(output_uri)
+        
+        print(f"Successfully counted words from {input_uri} and saved to {output_uri}")
+
+    except Exception as e:
+        print(f"Error during Spark execution: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        spark.stop()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds a new Spark job script for performing a word count on text data using PySpark. The script reads text files from HDFS, counts the occurrences of each word, and writes the results back to HDFS in CSV format. It also includes argument parsing, error handling, and usage instructions.

New Spark word count script:

* Added `spark/scripts/word_count.py`, which:
  - Parses command-line arguments for input and output HDFS paths and checks usage.
  - Initializes a Spark session and reads input text data from HDFS.
  - Splits lines into words, filters out empty strings, groups by word, and counts occurrences using PySpark DataFrame operations.
  - Writes the resulting word counts as CSV files to the specified HDFS output path.
  - Handles errors gracefully and ensures the Spark session is stopped after execution.