### PR TITLE
Change default infrastructure tier to 'minimal'

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -63,7 +63,7 @@ variable "ssh_public_key_ansible_runner" {
 variable "infrastructure_tier" {
   description = "Tier of infrastructure: minimal, standard, or high-performance"
   type        = string
-  default     = "standard"
+  default     = "minimal"
 }
 
 locals {


### PR DESCRIPTION
This pull request makes a small change to the default infrastructure tier in the Terraform configuration. The default value for the `infrastructure_tier` variable has been changed from "standard" to "minimal".